### PR TITLE
Add a test mode flag

### DIFF
--- a/overseer.go
+++ b/overseer.go
@@ -47,6 +47,9 @@ type Config struct {
 	PreUpgrade func(tempBinaryPath string) error
 	//Debug enables all [overseer] logs.
 	Debug bool
+	//Test disables fork and server restart to make it possible to unit test
+	//the server.
+	Test bool
 	//NoWarn disables warning [overseer] logs.
 	NoWarn bool
 	//NoRestart disables all restarts, this option essentially converts


### PR DESCRIPTION
The test mode flag allows to unit test the server, disabling the fork and the
service restart mechanisms.

Resolves #12