### PR TITLE
Allows binaries that require env configuration at runtime to be tested

### DIFF
--- a/proc_master.go
+++ b/proc_master.go
@@ -269,7 +269,7 @@ func (mp *master) fetch() {
 	//overseer sanity check, dont replace our good binary with a non-executable file
 	tokenIn := token()
 	cmd := exec.Command(tmpBinPath)
-	cmd.Env = []string{envBinCheck + "=" + tokenIn}
+	cmd.Env = append(os.Environ(), []string{envBinCheck + "=" + tokenIn}...)
 	returned := false
 	go func() {
 		time.Sleep(5 * time.Second)


### PR DESCRIPTION
In my 12 factor application part of the boot process is ensuring that the configuration providers (env, Consul, etcd, etc) have provided the baseline configuration for the app and panic if the configuration is unavailable. Previously the `fetch()` method only provided the sanity check token as an environment, but this caused upgrade failures for applications requiring env configuration at runtime.