### PR TITLE
If fetcher is disabled, don't test to move files

### DIFF
--- a/proc_master.go
+++ b/proc_master.go
@@ -90,11 +90,13 @@ func (mp *master) checkBinary() error {
 	mp.binHash = hash.Sum(nil)
 	f.Close()
 	//test bin<->tmpbin moves
-	if err := move(tmpBinPath, mp.binPath); err != nil {
-		return fmt.Errorf("cannot move binary (%s)", err)
-	}
-	if err := move(mp.binPath, tmpBinPath); err != nil {
-		return fmt.Errorf("cannot move binary back (%s)", err)
+	if mp.Config.Fetcher != nil {
+		if err := move(tmpBinPath, mp.binPath); err != nil {
+			return fmt.Errorf("cannot move binary (%s)", err)
+		}
+		if err := move(mp.binPath, tmpBinPath); err != nil {
+			return fmt.Errorf("cannot move binary back (%s)", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
If the user only wants graceful restarts from this library, and the user running the go program doesn't have write access to the path to the binary, overseer fails to start with an error 

`[overseer] disabled. run failed: cannot move binary (exit status 1)`

This commit checks if fetching is enabled, if not, it avoids the move check