### PR TITLE
rename command to avoid conflict

### DIFF
--- a/sys_posix.go
+++ b/sys_posix.go
@@ -33,10 +33,10 @@ func move(dst, src string) error {
 	}
 
 	// Run sync to 'commit' the mv by clearing caches
-	return sync().Run()
+	return syncCmd().Run()
 }
 
-func sync() *exec.Cmd {
+func syncCmd() *exec.Cmd {
 	return exec.Command("sync")
 }
 


### PR DESCRIPTION
Sorry about that.

Fixes:

```
vendor/github.com/jpillora/overseer/proc_master.go:17:2: sync redeclared in this block
	previous declaration at vendor/github.com/jpillora/overseer/sys_posix.go:39:14
```