### PR TITLE
Windows watchParent() fix

### DIFF
--- a/proc_slave.go
+++ b/proc_slave.go
@@ -79,26 +79,6 @@ func (sp *slave) run() error {
 	return nil
 }
 
-func (sp *slave) watchParent() error {
-	sp.masterPid = os.Getppid()
-	proc, err := os.FindProcess(sp.masterPid)
-	if err != nil {
-		return fmt.Errorf("master process: %s", err)
-	}
-	sp.masterProc = proc
-	go func() {
-		//send signal 0 to master process forever
-		for {
-			//should not error as long as the process is alive
-			if err := sp.masterProc.Signal(syscall.Signal(0)); err != nil {
-				os.Exit(1)
-			}
-			time.Sleep(2 * time.Second)
-		}
-	}()
-	return nil
-}
-
 func (sp *slave) initFileDescriptors() error {
 	//inspect file descriptors
 	numFDs, err := strconv.Atoi(os.Getenv(envNumFDs))

--- a/proc_slave_linux.go
+++ b/proc_slave_linux.go
@@ -1,0 +1,27 @@
+package overseer
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+func (sp *slave) watchParent() error {
+	sp.masterPid = os.Getppid()
+	proc, err := os.FindProcess(sp.masterPid)
+	if err != nil {
+		return fmt.Errorf("master process: %s", err)
+	}
+	sp.masterProc = proc
+	go func() {
+		//send signal 0 to master process forever
+		for {
+			//should not error as long as the process is alive
+			if err := sp.masterProc.Signal(syscall.Signal(0)); err != nil {
+				os.Exit(1)
+			}
+			time.Sleep(2 * time.Second)
+		}
+	}()
+	return nil
+}

--- a/proc_slave_others.go
+++ b/proc_slave_others.go
@@ -1,3 +1,4 @@
+// +build !windows
 package overseer
 
 import (

--- a/proc_slave_others.go
+++ b/proc_slave_others.go
@@ -1,4 +1,5 @@
 // +build !windows
+
 package overseer
 
 import (

--- a/proc_slave_windows.go
+++ b/proc_slave_windows.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package overseer
 
 import (

--- a/proc_slave_windows.go
+++ b/proc_slave_windows.go
@@ -1,0 +1,29 @@
+package overseer
+
+import (
+	"fmt"
+	"github.com/shirou/gopsutil/process"
+	"os"
+	"syscall"
+	"time"
+)
+
+func (sp *slave) watchParent() error {
+	sp.masterPid = os.Getppid()
+	proc, err := os.FindProcess(sp.masterPid)
+	if err != nil {
+		return fmt.Errorf("master process: %s", err)
+	}
+	sp.masterProc = proc
+	go func() {
+		//check process exists
+		for {
+			//should not error as long as the process is alive
+			if _, err := process.GetWin32Proc(int32(sp.masterPid)); err != nil {
+				os.Exit(1)
+			}
+			time.Sleep(2 * time.Second)
+		}
+	}()
+	return nil
+}


### PR DESCRIPTION
Slave process watches its parent by sending Signal(0), but as stated in `os/exec.go` sending Interrupt on Windows is not implemented. This cause prog exits with status code 1 error.
```
// Signal sends a signal to the Process.
// Sending Interrupt on Windows is not implemented.
func (p *Process) Signal(sig Signal) error {
	return p.signal(sig)
}
```

This fix uses `gopsutil` to check for process existence on Windows.