### PR TITLE
split fetcher package, reduce binary to 3MB if AWS S3 fetcher not used

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import (
 	"time"
 
 	"github.com/jpillora/overseer"
-	"github.com/jpillora/overseer/fetcher"
+	"github.com/jpillora/overseer/fetcher/http"
 )
 
 //create another main() to run the overseer process
@@ -44,7 +44,7 @@ func main() {
 	overseer.Run(overseer.Config{
 		Program: prog,
 		Address: ":3000",
-		Fetcher: &fetcher.HTTP{
+		Fetcher: &fetcherHttp.HTTP{
 			URL:      "http://localhost:4000/binaries/myapp",
 			Interval: 1 * time.Second,
 		},
@@ -124,7 +124,7 @@ func main() {
 	overseer.Run(overseer.Config{
 		Program: prog,
 		NoRestart: true,
-		Fetcher: &fetcher.HTTP{
+		Fetcher: &fetcherHttp.HTTP{
 			URL:      "http://localhost:4000/binaries/myapp",
 			Interval: 1 * time.Second,
 		},

--- a/example/main.go
+++ b/example/main.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/jpillora/overseer"
-	"github.com/jpillora/overseer/fetcher"
+	"github.com/jpillora/overseer/fetcher/file"
 )
 
 //see example.sh for the use-case
@@ -33,7 +33,7 @@ func main() {
 	overseer.Run(overseer.Config{
 		Program: prog,
 		Address: ":5001",
-		Fetcher: &fetcher.File{Path: "my_app_next"},
+		Fetcher: &fetcherFile.File{Path: "my_app_next"},
 		Debug:   false, //display log of overseer actions
 	})
 }

--- a/fetcher/file/fetcher_file.go
+++ b/fetcher/file/fetcher_file.go
@@ -1,4 +1,4 @@
-package fetcher
+package fetcherFile
 
 import (
 	"errors"

--- a/fetcher/github/fetcher_github.go
+++ b/fetcher/github/fetcher_github.go
@@ -1,4 +1,4 @@
-package fetcher
+package fetcherGithub
 
 import (
 	"compress/gzip"

--- a/fetcher/http/fetcher_http.go
+++ b/fetcher/http/fetcher_http.go
@@ -1,4 +1,4 @@
-package fetcher
+package fetcherHttp
 
 import (
 	"compress/gzip"

--- a/fetcher/s3/fetcher_s3.go
+++ b/fetcher/s3/fetcher_s3.go
@@ -1,4 +1,4 @@
-package fetcher
+package fetcherS3
 
 import (
 	"compress/gzip"

--- a/overseer.go
+++ b/overseer.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/jpillora/overseer/fetcher"
+	"github.com/kokizzu/overseer/fetcher"
 )
 
 const (

--- a/sys_posix.go
+++ b/sys_posix.go
@@ -1,4 +1,4 @@
-// +build linux darwin
+// +build linux darwin freebsd
 
 package overseer
 

--- a/sys_unsupported.go
+++ b/sys_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!darwin,!windows
+// +build !linux,!darwin,!windows,!freebsd
 
 package overseer
 


### PR DESCRIPTION
split fetcher package, reducing binary size by 3 MB if AWS S3 not used.

fixes https://github.com/jpillora/overseer/issues/44