### PR TITLE
Fixes S3 fetcher return

### DIFF
--- a/fetcher/fetcher_s3.go
+++ b/fetcher/fetcher_s3.go
@@ -122,5 +122,5 @@ func (s *S3) Fetch() (io.Reader, error) {
 		return gzip.NewReader(resp.Body)
 	}
 	//success!
-	return nil, nil
+	return resp.Body, nil
 }


### PR DESCRIPTION
If the file is not gzipped the `Fetcher` should return the `http.Response.Body` and not nil